### PR TITLE
fix binding/telemetry

### DIFF
--- a/src/protocol/dsm_receiver.c
+++ b/src/protocol/dsm_receiver.c
@@ -326,7 +326,7 @@ void dsm_receiver_receive_cb(bool error) {
 		memcpy(usbrf_config.dsm_bind_mfg_id, dsm_receiver.mfg_id, 4);
 		usbrf_config.dsm_num_channels = packet[11];
 		usbrf_config.dsm_protocol = packet[12];
-		config_store();
+		//config_store();
 
 		// Start receiver
 		dsm_receiver_start_transfer();


### PR DESCRIPTION
- update libopencm3
- don't save to flash in dsm_receiver_receive_cb, maybe takes too long and things get out of sync???

This fixes USBRF for me, I can bind again and get telemetry....

Maybe also closes #4 ?
